### PR TITLE
fix(plugin-klaviyo): align @PluginSubGroup titles with metadata YAML

### DIFF
--- a/src/main/java/io/kestra/plugin/klaviyo/campaign/messages/package-info.java
+++ b/src/main/java/io/kestra/plugin/klaviyo/campaign/messages/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Campaign Messages",
+    title = "Klaviyo Campaign Messages",
     description = "Tasks for managing Klaviyo campaign messages and related images.", categories = {
         PluginSubGroup.PluginCategory.AI,
         PluginSubGroup.PluginCategory.BUSINESS

--- a/src/main/java/io/kestra/plugin/klaviyo/campaign/package-info.java
+++ b/src/main/java/io/kestra/plugin/klaviyo/campaign/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Campaign",
+    title = "Klaviyo Campaign",
     description = "Tasks for managing Klaviyo campaigns and recipient estimations.", categories = {
         PluginSubGroup.PluginCategory.AI,
         PluginSubGroup.PluginCategory.BUSINESS

--- a/src/main/java/io/kestra/plugin/klaviyo/jobs/package-info.java
+++ b/src/main/java/io/kestra/plugin/klaviyo/jobs/package-info.java
@@ -1,5 +1,5 @@
 @PluginSubGroup(
-    title = "Campaign Jobs",
+    title = "Klaviyo Campaign Jobs",
     description = "Tasks for managing Klaviyo campaign recipient estimation jobs and send jobs.", categories = {
         PluginSubGroup.PluginCategory.AI,
         PluginSubGroup.PluginCategory.BUSINESS


### PR DESCRIPTION
## Summary

- Updates `@PluginSubGroup(title = ...)` in `package-info.java` files to match the `title` field in the corresponding subgroup metadata YAML files
- Eliminates duplicate/empty subgroup URLs on kestra.io caused by the annotation falling back to the package name when no title is set, while metadata uses a different slug

## Test plan

- [ ] Verify kestra.io subgroup pages no longer show empty duplicate routes after merge